### PR TITLE
Set a hard limit on loaded chunks

### DIFF
--- a/src/main/java/com/gecgooden/chunkgen/handlers/ConfigurationHandler.java
+++ b/src/main/java/com/gecgooden/chunkgen/handlers/ConfigurationHandler.java
@@ -34,6 +34,7 @@ public class ConfigurationHandler {
 		Reference.height = configuration.get(Configuration.CATEGORY_GENERAL, "height", 0, "Height starting value").getInt();
 		Reference.width = configuration.get(Configuration.CATEGORY_GENERAL, "width", 0, "Width starting value").getInt();
 		Reference.pauseForPlayers = configuration.get(Configuration.CATEGORY_GENERAL, "pauseForPlayers", true, "Pause chunk generation when players are logged on").getBoolean();
+		Reference.maxChunksLoaded = configuration.get(Configuration.CATEGORY_GENERAL, "maxChunksLoaded", 3000, "Pause chunk generation if more chunks than this are in memory").getInt();
 		Reference.numChunksPerTick = configuration.get(Configuration.CATEGORY_GENERAL, "numChunksPerTick", 1.0, "Number of chunks loaded per tick").getDouble();
 		Reference.updateDelay = configuration.get(Configuration.CATEGORY_GENERAL, "updateDelay", 40, "Number of chunks inbetween percentage updates").getInt();
 		Reference.skipChunks = getSkipChunks().getInt();

--- a/src/main/java/com/gecgooden/chunkgen/handlers/TickHandler.java
+++ b/src/main/java/com/gecgooden/chunkgen/handlers/TickHandler.java
@@ -11,19 +11,30 @@ import com.gecgooden.chunkgen.util.Utilities;
 import cpw.mods.fml.common.eventhandler.SubscribeEvent;
 import cpw.mods.fml.common.gameevent.TickEvent;
 import net.minecraft.world.World;
+import net.minecraft.world.WorldServer;
 
 public class TickHandler {
 
 	private double chunkQueue = 0;
 	private int chunksGenerated = 0;
 
+	int getChunksLoaded() {
+		int total = 0;
+		for (WorldServer worldServer : MinecraftServer.getServer().worldServers) {
+			total += worldServer.getChunkProvider().getLoadedChunkCount();
+		}
+		return total;
+	}
+
 	@SubscribeEvent
 	public void onServerTick(TickEvent.ServerTickEvent event) {
 		// Note that this only works on dedicated servers.
-		final World world = MinecraftServer.getServer().getEntityWorld();
-		if (Reference.pauseForPlayers && world.playerEntities.size() > 0) return;
 
 		if(Reference.toGenerate != null && !Reference.toGenerate.isEmpty()) {
+			final World world = MinecraftServer.getServer().getEntityWorld();
+			if (Reference.pauseForPlayers && world.playerEntities.size() > 0) return;
+			if (Reference.maxChunksLoaded <= getChunksLoaded()) return;
+
 			chunkQueue += Reference.numChunksPerTick;
 			while (chunkQueue > 1) {
 				chunkQueue--;

--- a/src/main/java/com/gecgooden/chunkgen/reference/Reference.java
+++ b/src/main/java/com/gecgooden/chunkgen/reference/Reference.java
@@ -14,6 +14,7 @@ public class Reference {
     public static Integer width;
     public static double numChunksPerTick;
     public static boolean pauseForPlayers;
+    public static Integer maxChunksLoaded;
 
     public static final String MOD_ID = "chunkgen";
     public static final String VERSION = "1.7.10-1.2.2";


### PR DESCRIPTION
As I find that the server can get overloaded, bogged down and stop working if too many chunks are generated at once.

This patch attempts to detect that condition, and pause until it's written out more chunks. The default limit of 3000 chunks is pretty generous, but is intended to let chunkgen keep working even on a populated server.

It's intended to be applied to the 1.7.10 branch. Couldn't find it, though.