### PR TITLE
#25 Chunks are not generated on 1.10.2

### DIFF
--- a/src/main/java/com/gecgooden/chunkgen/util/Utilities.java
+++ b/src/main/java/com/gecgooden/chunkgen/util/Utilities.java
@@ -121,7 +121,7 @@ public class Utilities {
         final Vec3d zerovec = new Vec3d(x, 0, z);
         BiConsumer<Integer, Integer> addChunk = (xpos,zpos) -> {
             //guard for range
-            if (zerovec.distanceTo(new Vec3d(xpos, 0, zpos)) <= radius) {
+            if (zerovec.distanceTo(new Vec3d(xpos, 0, zpos)) > radius) {
                 return;
             }
             Reference.toGenerate.add(new ChunkPosition(xpos, zpos, dimensionID, icommandsender, logToChat));
@@ -137,7 +137,7 @@ public class Utilities {
         BiConsumer<Integer, Integer> addChunk = (xpos,zpos) -> {
             //guard for range
             if (xpos > xmax || xpos < xmin
-                    || zpos > zmax || xpos < zmin) {
+                    || zpos > zmax || zpos < zmin) {
                 return;
             }
             Reference.toGenerate.add(new ChunkPosition(xpos, zpos, dimensionID, icommandsender, logToChat));

--- a/src/main/java/com/gecgooden/chunkgen/util/Utilities.java
+++ b/src/main/java/com/gecgooden/chunkgen/util/Utilities.java
@@ -60,13 +60,11 @@ public class Utilities {
     public static void generateChunk(MinecraftServer server, int x, int z, int dimensionID) {
 		ChunkProviderServer cps = server.worldServerForDimension(dimensionID).getChunkProvider();
 		if(!chunkPrepared(cps, x, z, dimensionID)) {
-			cps.loadChunk(x, z);
+			cps.provideChunk(x, z).needsSaving(true);
 
-			cps.loadChunk(x, z+1);
-			cps.loadChunk(x+1, z);
-			cps.loadChunk(x+1, z+1);
-
-
+			cps.provideChunk(x, z+1).needsSaving(true);
+			cps.provideChunk(x+1, z).needsSaving(true);
+			cps.provideChunk(x+1, z+1).needsSaving(true);
 		}
 	}
 


### PR DESCRIPTION
I was able to get the terrain to properly generate by changing loadChunk to provideChunk and then marking that it needed saving.

In the process, I found some bounds checking issues that caused my server to generate 32,000 chunks more than I wanted.